### PR TITLE
Fix start script to correctly call migration command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "install": "cd server && npm install && cd ../client && npm install",
     "build": "cd server && npm run build && cd ../client && npm run build",
-    "start": "cd server && npm migrate && npm start",
+    "start": "cd server && npm run migrate && npm start",
     "migrate": "npx sequelize-cli db:migrate --migrations-path server/dist/migrations --config server/dist/config/database.cjs",
     "migrate:undo": "npx sequelize-cli db:migrate:undo --migrations-path server/dist/migrations --config server/dist/config/database.cjs",
     "start:dev": "concurrently \"npm run server:dev\" \"wait-on tcp:3001 && npm run client:dev\"",


### PR DESCRIPTION
Replaced `npm migrate` with `npm run migrate` in the `start` script to ensure the migration command is executed properly. This resolves potential issues caused by an incorrect script reference.