### PR TITLE
Update start script to include database migration step

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "install": "cd server && npm install && cd ../client && npm install",
     "build": "cd server && npm run build && cd ../client && npm run build",
-    "start": "cd server && npm start",
+    "start": "cd server && npm run migrate && npm start",
     "migrate": "npx sequelize-cli db:migrate --migrations-path server/dist/migrations --config server/dist/config/database.cjs",
     "migrate:undo": "npx sequelize-cli db:migrate:undo --migrations-path server/dist/migrations --config server/dist/config/database.cjs",
     "start:dev": "concurrently \"npm run server:dev\" \"wait-on tcp:3001 && npm run client:dev\"",


### PR DESCRIPTION
The "start" script now runs database migrations before starting the server. This ensures the database is always up-to-date when the application starts, improving deployment reliability.